### PR TITLE
Allow sorting on multiple fields

### DIFF
--- a/grails-app/services/org/grails/plugins/quickSearch/QuickSearchService.groovy
+++ b/grails-app/services/org/grails/plugins/quickSearch/QuickSearchService.groovy
@@ -73,8 +73,13 @@ class QuickSearchService {
 
          // sorting
          if (searchParams?.sort && searchParams?.order) {
-            def sortAlias = aliasBuilder(domainClass, searchParams.sort, aliasesList)
-            order(sortAlias, searchParams.order)
+            def sortAliases = ((String) searchParams.sort).split(",").collect {aliasBuilder(domainClass, it.trim(), aliasesList)}
+            def sortOrders = ((String) searchParams.order).split(",")
+            and {
+                sortAliases.each {
+                    order(it, sortOrders[sortAliases.indexOf(it)].trim())
+                }
+            }
          }
 
          // distinct
@@ -117,8 +122,13 @@ class QuickSearchService {
                aliasBuilder.delegate = delegate
                // sorting
                if (searchParams?.sort && searchParams?.order) {
-                  def sortAlias = aliasBuilder(domainClass, searchParams.sort, [])
-                  order(sortAlias, searchParams.order)
+                  def sortAliases = ((String) searchParams.sort).split(",").collect {aliasBuilder(domainClass, it.trim(), aliasesList)}
+                  def sortOrders = ((String) searchParams.order).split(",")
+                  and {
+                      sortAliases.each {
+                          order(it, sortOrders[sortAliases.indexOf(it)].trim())
+                      }
+                  }
                }
                // get by ids
                'in'("id", result)


### PR DESCRIPTION
Example usage: def searchParams = [sort: 'firstName,lastName', order: 'asc,desc']
Intended as a fix for https://github.com/tadodotcom/grails-quick-search/issues/11 (closes #11)

Note: There is currently no check whether the arguments are valid (same number of sort fields as order arguments)