### PR TITLE
handle list properties in search to avoid log message

### DIFF
--- a/src/groovy/org/grails/plugins/quickSearch/QuickSearchUtil.groovy
+++ b/src/groovy/org/grails/plugins/quickSearch/QuickSearchUtil.groovy
@@ -123,6 +123,8 @@ class QuickSearchUtil {
                catch (NumberFormatException e) {
                   log.warn "Queried string [$query] could not be translated to number."
                }
+         } else if (ClassUtils.isAssignable(property.class, Collection.class)) {
+            return property.any{ matchSearch(it, query) }
          } else {
             log.error "Unsupported class type [${property.class}] for quick search, omitting."
          }


### PR DESCRIPTION
The quick search is working fine even for array search-properties. But each search request creates a log message with content:

    ERROR Unsupported class type [class java.util.ArrayList] for quick search, omitting.

This change properly handles that case.
Instead of just suppressing the log statement, a recursive search is executed. There's no visible difference, but just avoiding the message doesn't feel right.