### PR TITLE
fix exception when searching without explicit list of search properties

### DIFF
--- a/src/groovy/org/grails/plugins/quickSearch/QuickSearchUtil.groovy
+++ b/src/groovy/org/grails/plugins/quickSearch/QuickSearchUtil.groovy
@@ -20,7 +20,7 @@ class QuickSearchUtil {
    private static final String TOKENIZE_WRAPPER = '"'
 
    static getDomainClassProperties(grailsApplication, domainClass, boolean strings = true, boolean numbers = true) {
-      def properties = [] + grailsApplication.getDomainClass(domainClass.name).persistentProperties
+      def properties = grailsApplication.getDomainClass(domainClass.name).persistentProperties as List
 
       if (getConf(grailsApplication).searchIdentifier) {
          properties << grailsApplication.getDomainClass(domainClass.name).identifier


### PR DESCRIPTION
If `searchProperties` were not specified, then the following exception was raised on search:
```
No signature of method: static org.apache.commons.lang.ClassUtils.isAssignable() is applicable for argument types: (java.util.ArrayList, java.lang.Class, java.lang.Boolean) values: [[class com.tado.setup.installation.InstallerAppointment, ...], ...]
Possible solutions: isAssignable(java.lang.Class, java.lang.Class, boolean), isAssignable(java.lang.Class, java.lang.Class), isAssignable([Ljava.lang.Class;, [Ljava.lang.Class;, boolean), isAssignable([Ljava.lang.Class;, [Ljava.lang.Class;). Stacktrace follows:
Message: No signature of method: static org.apache.commons.lang.ClassUtils.isAssignable() is applicable for argument types: (java.util.ArrayList, java.lang.Class, java.lang.Boolean) values: [[class com.tado.setup.installation.InstallerAppointment, ...], ...]
Possible solutions: isAssignable(java.lang.Class, java.lang.Class, boolean), isAssignable(java.lang.Class, java.lang.Class), isAssignable([Ljava.lang.Class;, [Ljava.lang.Class;, boolean), isAssignable([Ljava.lang.Class;, [Ljava.lang.Class;)
```

Existing code used `[] +`, probably to type cast persistent properties to something iterable. But the result was really an array of array. This PR explicitly converts to `List`, solving the problem and getting rid of the Exception.