### PR TITLE
Force the conversion of the alias from GString to String to make the Grails Melody plugin work

### DIFF
--- a/grails-app/services/grails/plugin/quickSearch/QuickSearchService.groovy
+++ b/grails-app/services/grails/plugin/quickSearch/QuickSearchService.groovy
@@ -229,7 +229,7 @@ class QuickSearchService {
          }
       }
 
-      return finalAlias
+      return finalAlias.toString()
    }
 
    /**


### PR DESCRIPTION
Without this change, the Grails Melody plugin fails on calling propertyQueryBuilder() when the alias is a GString (so for association / nested properties).