### PR TITLE
define nesting properties in searchProperties on Grails 3.2.11 > get …

### DIFF
--- a/grails-app/services/grails/plugin/quickSearch/QuickSearchService.groovy
+++ b/grails-app/services/grails/plugin/quickSearch/QuickSearchService.groovy
@@ -235,7 +235,7 @@ class QuickSearchService {
    /**
     * The actual query builder
     */
-   def propertyQueryBuilder = { domainClass, property, String propertyAlias, String queryString ->
+   def propertyQueryBuilder = { domainClass, property, propertyAlias, String queryString ->
       def propertyType = (property instanceof GrailsDomainClassProperty) ? property.getType() : QuickSearchUtil.getPropertyType(grailsApplication, domainClass, property)
 
       // set search


### PR DESCRIPTION
…rise error of class cast exception

I found the error cause in QuickSearchService line 238
def propertyQueryBuilder = { domainClass, property, String propertyAlias, String queryString ->
the propertyAlias is not always String.